### PR TITLE
FIX: Use the request expanded field instead of command.

### DIFF
--- a/autoload/dispatch/neovim.vim
+++ b/autoload/dispatch/neovim.vim
@@ -56,7 +56,7 @@ endfunction
 
 function! dispatch#neovim#handle(request) abort
 	let action = a:request.action
-	let cmd = a:request.command
+	let cmd = a:request.expanded
 	let bg = a:request.background
 	let opts = s:CommandOptions(a:request)
 	if s:UsesTerminal(a:request)


### PR DESCRIPTION
By using the field `command` of the `request`, calling something like this

``` vim
:Dispatch ruby %
```

Will open a `:terminal` with the same literal command:

``` vim
term://ruby\ %
```

We need to use the `expanded` field which already converts all expandable characters. So this command:

``` vim
:Dispatch ruby %
```

Will become:

``` vim
term://ruby\ path/to/current/file.rb
```
