### PR TITLE
Use `writefile` with `getbufline` in JobExit

### DIFF
--- a/autoload/dispatch/neovim.vim
+++ b/autoload/dispatch/neovim.vim
@@ -153,10 +153,7 @@ endfunction
 
 function! s:JobExit(job_id, data, event) abort
 	if s:UsesTerminal(self.request) && s:NeedsOutput(self.request)
-		let buffer = bufnr('%')
-		execute 'silent keepalt buffer ' . self.buf_id
-		execute 'silent keepalt write '. self.tempfile
-		execute 'silent keepalt buffer ' . buffer
+		call writefile(getbufline(self.buf_id, 1, '$'), self.tempfile)
 	endif
 
 	" Clean up terminal window if visible


### PR DESCRIPTION
This is more sane (removes three silented commands!) and fixes an issue,
where this would fail ("Not allowed here") in case a hit-enter prompt
was displayed by vim-dispatch [1].

This would then cause the JobExit function to abort and not handle the
output/closing at all.

1: https://github.com/tpope/vim-dispatch/blob/eb3e564fb1edfee09fe6aeb57f3388e273da72c8/autoload/dispatch.vim#L218-L219
